### PR TITLE
Add landing page for configuring games

### DIFF
--- a/src/BenchBoss/BenchBoss.fs
+++ b/src/BenchBoss/BenchBoss.fs
@@ -25,6 +25,7 @@ module Component =
 
         // Page content based on current page
         match state.CurrentPage with
+        | LandingPage -> LandingPage.render state dispatch
         | GamePage -> GamePage.render state dispatch
         | ManageTeamPage -> ManageTeamPage.render state dispatch
 

--- a/src/BenchBoss/GamePage.fs
+++ b/src/BenchBoss/GamePage.fs
@@ -165,10 +165,11 @@ module GamePage =
       |> List.filter (fun p -> p.InGameStatus = OnField)
       |> List.sortBy (fun p -> p.PlayedSeconds)
     
-    // For now, create dummy field slots to maintain the 4-slot layout
-    let fieldPlayers = 
-      let playerArray = Array.create 4 None
-      onFieldPlayers |> List.iteri (fun i p -> if i < 4 then playerArray[i] <- Some p)
+    // Create field slots based on the configured number of positions
+    let totalSlots = max 1 state.Game.FieldSlots
+    let fieldPlayers =
+      let playerArray = Array.create totalSlots None
+      onFieldPlayers |> List.iteri (fun i p -> if i < totalSlots then playerArray[i] <- Some p)
       playerArray
     
     Html.div [

--- a/src/BenchBoss/LandingPage.fs
+++ b/src/BenchBoss/LandingPage.fs
@@ -1,0 +1,247 @@
+namespace BenchBossApp.Components.BenchBoss
+
+open System
+open Feliz
+open BenchBossApp.Components.BenchBoss.Types
+
+module LandingPage =
+
+  let private maxSlots = 11
+
+  let private playerCheckbox (selected:Set<PlayerId>) (dispatch: Msg -> unit) (player: TeamPlayer) =
+    let isSelected = selected.Contains player.Id
+
+    Html.label [
+      prop.className "flex items-center justify-between gap-3 p-3 border border-purple-100 rounded-lg hover:border-purple-300 transition-colors cursor-pointer"
+      prop.children [
+        Html.div [
+          prop.className "flex items-center gap-3"
+          prop.children [
+            Html.input [
+              prop.type' "checkbox"
+              prop.isChecked isSelected
+              prop.onChange (fun (_: bool) -> dispatch (TogglePlayerGameAvailability player.Id))
+              prop.className "h-5 w-5 text-purple-600 rounded focus:ring-purple-500"
+            ]
+            Html.span [
+              prop.className "text-lg font-medium text-gray-800"
+              prop.text player.Name
+            ]
+          ]
+        ]
+        if isSelected then
+          Html.span [
+            prop.className "text-sm font-medium text-purple-600"
+            prop.text "Selected"
+          ]
+        else
+          Html.none
+      ]
+    ]
+
+  let private fieldSlotSelector (state: State) (dispatch: Msg -> unit) =
+    let handleChange (value: string) =
+      match Int32.TryParse value with
+      | true, parsed -> dispatch (SetFieldSlots parsed)
+      | _ -> ()
+
+    Html.div [
+      prop.className "space-y-3"
+      prop.children [
+        Html.div [
+          prop.className "flex items-center justify-between"
+          prop.children [
+            Html.span [
+              prop.className "text-lg font-semibold text-gray-800"
+              prop.text "Field positions"
+            ]
+            Html.span [
+              prop.className "text-2xl font-bold text-purple-600"
+              prop.text (string state.Game.FieldSlots)
+            ]
+          ]
+        ]
+        Html.input [
+          prop.type' "range"
+          prop.className "w-full"
+          prop.min 1
+          prop.max maxSlots
+          prop.step 1
+          prop.value state.Game.FieldSlots
+          prop.onChange handleChange
+        ]
+        Html.div [
+          prop.className "flex items-center gap-3"
+          prop.children [
+            Html.input [
+              prop.type' "number"
+              prop.className "w-20 border border-purple-200 rounded-lg px-2 py-1"
+              prop.min 1
+              prop.max maxSlots
+              prop.value state.Game.FieldSlots
+              prop.onChange handleChange
+            ]
+            Html.p [
+              prop.className "text-sm text-gray-500"
+              prop.text "Choose how many players will start on the field."
+            ]
+          ]
+        ]
+      ]
+    ]
+
+  let private selectedSummary (state: State) =
+    let selectedCount = state.Game.Players.Length
+    let difference = state.Game.FieldSlots - selectedCount
+
+    Html.div [
+      prop.className "grid grid-cols-2 gap-4"
+      prop.children [
+        Html.div [
+          prop.className "bg-purple-50 rounded-lg p-4"
+          prop.children [
+            Html.p [
+              prop.className "text-sm text-purple-700"
+              prop.text "Players selected"
+            ]
+            Html.p [
+              prop.className "text-2xl font-semibold text-purple-900"
+              prop.text (string selectedCount)
+            ]
+          ]
+        ]
+        Html.div [
+          prop.className "bg-purple-50 rounded-lg p-4"
+          prop.children [
+            Html.p [
+              prop.className "text-sm text-purple-700"
+              prop.text "Spots remaining"
+            ]
+            Html.p [
+              prop.className "text-2xl font-semibold text-purple-900"
+              prop.text (
+                if difference > 0 then string difference else "0"
+              )
+            ]
+          ]
+        ]
+      ]
+    ]
+
+  let render (state: State) (dispatch: Msg -> unit) =
+    let selectedPlayers = state.Game.Players |> List.map _.Id |> Set.ofList
+    let selectedCount = selectedPlayers |> Set.count
+    let missingPlayers = max 0 (state.Game.FieldSlots - selectedCount)
+    let canStart = selectedCount > 0
+
+    Html.div [
+      prop.className "flex-1 bg-gradient-to-b from-purple-50 to-white py-10"
+      prop.children [
+        Html.div [
+          prop.className "max-w-5xl mx-auto px-4 space-y-8"
+          prop.children [
+            Html.div [
+              prop.className "space-y-3 text-center md:text-left"
+              prop.children [
+                Html.h1 [
+                  prop.className "text-4xl font-extrabold text-purple-900"
+                  prop.text "Set up your match"
+                ]
+                Html.p [
+                  prop.className "text-lg text-purple-700"
+                  prop.text "Name your game, pick who is playing, and choose how many spots you need on the field."
+                ]
+              ]
+            ]
+
+            Html.div [
+              prop.className "grid gap-8 md:grid-cols-2"
+              prop.children [
+                Html.div [
+                  prop.className "bg-white rounded-xl shadow-lg p-6 space-y-6"
+                  prop.children [
+                    Html.div [
+                      prop.className "space-y-2"
+                      prop.children [
+                        Html.label [
+                          prop.className "text-lg font-semibold text-gray-800"
+                          prop.text "Game name"
+                        ]
+                        Html.input [
+                          prop.type' "text"
+                          prop.className "w-full border border-purple-200 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-purple-400"
+                          prop.placeholder "Saturday scrimmage"
+                          prop.value state.Game.Name
+                          prop.onChange (fun value -> dispatch (UpdateGameName value))
+                        ]
+                      ]
+                    ]
+
+                    fieldSlotSelector state dispatch
+
+                    selectedSummary state
+
+                    if missingPlayers > 0 then
+                      Html.p [
+                        prop.className "text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2"
+                        prop.text $"Add {missingPlayers} more player(s) to fill every position."
+                      ]
+                    else
+                      Html.p [
+                        prop.className "text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-3 py-2"
+                        prop.text "You're ready to take the field!"
+                      ]
+
+                    Html.button [
+                      prop.className "w-full px-6 py-3 bg-purple-600 text-white rounded-lg font-semibold hover:bg-purple-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                      prop.disabled (not canStart)
+                      prop.onClick (fun _ -> dispatch StartGame)
+                      prop.text "Start game"
+                    ]
+                  ]
+                ]
+
+                Html.div [
+                  prop.className "bg-white rounded-xl shadow-lg p-6 space-y-4"
+                  prop.children [
+                    Html.div [
+                      prop.className "flex items-center justify-between"
+                      prop.children [
+                        Html.h2 [
+                          prop.className "text-2xl font-semibold text-gray-900"
+                          prop.text "Choose your players"
+                        ]
+                        Html.span [
+                          prop.className "text-sm text-gray-500"
+                          prop.text $"{selectedCount} selected"
+                        ]
+                      ]
+                    ]
+
+                    if state.TeamPlayers.IsEmpty then
+                      Html.div [
+                        prop.className "text-center space-y-2"
+                        prop.children [
+                          Html.p [
+                            prop.className "text-gray-600"
+                            prop.text "No players yet. Head to team management to build your roster."
+                          ]
+                        ]
+                      ]
+                    else
+                      Html.div [
+                        prop.className "space-y-2 max-h-[26rem] overflow-y-auto pr-1"
+                        prop.children (
+                          state.TeamPlayers
+                          |> List.sortBy (fun p -> p.Name)
+                          |> List.map (playerCheckbox selectedPlayers dispatch)
+                        )
+                      ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]

--- a/src/BenchBoss/Layout.fs
+++ b/src/BenchBoss/Layout.fs
@@ -4,6 +4,51 @@ module Layout =
   open Feliz
   open BenchBossApp.Components.BenchBoss.Types
 
+  let private navButton iconSrc alt ariaLabel title onClick =
+    Html.button [
+      prop.className "bg-purple-600 hover:bg-purple-500 focus:ring-2 focus:ring-purple-300 text-white rounded-full w-10 h-10 inline-flex items-center justify-center shadow transition-colors"
+      prop.ariaLabel ariaLabel
+      prop.title title
+      prop.onClick (fun _ -> onClick ())
+      prop.children [
+        Html.img [
+          prop.src iconSrc
+          prop.alt alt
+          prop.className "w-5 h-5"
+        ]
+      ]
+    ]
+
+  let private navigationButtons (dispatch: Msg -> unit) (state: State) =
+    let manageTeamButton () =
+      navButton
+        "assets/team.svg"
+        "Team Management"
+        "Team Management"
+        "Manage Teams and Players"
+        (fun () -> dispatch (NavigateToPage ManageTeamPage))
+
+    let gameButton () =
+      navButton
+        "assets/soccer.svg"
+        "Soccer Game"
+        "Back to Soccer Game"
+        "Back to Soccer Game"
+        (fun () -> dispatch (NavigateToPage GamePage))
+
+    let landingButton () =
+      navButton
+        "assets/play.svg"
+        "Game Setup"
+        "Game Setup"
+        "Game Setup"
+        (fun () -> dispatch (NavigateToPage LandingPage))
+
+    match state.CurrentPage with
+    | LandingPage -> [ manageTeamButton () ]
+    | GamePage -> [ manageTeamButton (); landingButton () ]
+    | ManageTeamPage -> [ gameButton (); landingButton () ]
+
   let render (dispatch: Msg -> unit) (state: State) =
     Html.div [
       prop.className "flex flex-col"
@@ -15,79 +60,64 @@ module Layout =
             Html.div [
               prop.className "w-10"
             ]
-            
-            Html.div [
-              prop.className "bg-purple-600 p-2 rounded-lg flex items-center gap-2"
-              prop.children [
-                // Our score (clickable)
-                Html.button [
-                  prop.className "hover:bg-purple-700 px-4 py-2 rounded-lg transition-colors"
-                  prop.text (string state.OurScore)
-                  prop.onClick (fun _ -> dispatch (ShowModal OurTeamScoreModal))
-                  prop.title "Click to add score for our team"
-                ]
-                Html.span [
-                  prop.className "mx-2"
-                  prop.text "-"
-                ]
-                // Their score (clickable)
-                Html.button [
-                  prop.className "hover:bg-purple-700 px-4 py-2 rounded-lg transition-colors"
-                  prop.text (string state.OppScore)
-                  prop.onClick (fun _ -> dispatch (ShowModal OpposingTeamScoreModal))
-                  prop.title "Click to add score for opposing team"
+
+            match state.CurrentPage with
+            | LandingPage ->
+              Html.div [
+                prop.className "px-4 py-2 rounded-lg bg-purple-600 bg-opacity-80"
+                prop.children [
+                  Html.span [
+                    prop.className "text-white text-2xl font-semibold tracking-wide"
+                    prop.text "BenchBoss"
+                  ]
                 ]
               ]
-            ]
-            
-            // Navigation icon in top right (changes based on current page)
-            Html.div [
-              prop.className "flex items-center"
-              prop.children [
-                match state.CurrentPage with
-                | GamePage ->
+            | _ ->
+              Html.div [
+                prop.className "bg-purple-600 p-2 rounded-lg flex items-center gap-2"
+                prop.children [
+                  // Our score (clickable)
                   Html.button [
-                    prop.className "bg-purple-600 hover:bg-purple-500 focus:ring-2 focus:ring-purple-300 text-white rounded-full w-10 h-10 inline-flex items-center justify-center shadow transition-colors"
-                    prop.ariaLabel "Team Management"
-                    prop.title "Manage Teams and Players"
-                    prop.onClick (fun _ -> dispatch (NavigateToPage ManageTeamPage))
-                    prop.children [
-                      Html.img [
-                        prop.src "assets/team.svg"
-                        prop.alt "Team Management"
-                        prop.className "w-5 h-5"
-                      ]
-                    ]
+                    prop.className "hover:bg-purple-700 px-4 py-2 rounded-lg transition-colors"
+                    prop.text (string state.OurScore)
+                    prop.onClick (fun _ -> dispatch (ShowModal OurTeamScoreModal))
+                    prop.title "Click to add score for our team"
                   ]
-                | ManageTeamPage ->
+                  Html.span [
+                    prop.className "mx-2"
+                    prop.text "-"
+                  ]
+                  // Their score (clickable)
                   Html.button [
-                    prop.className "bg-purple-600 hover:bg-purple-500 focus:ring-2 focus:ring-purple-300 text-white rounded-full w-10 h-10 inline-flex items-center justify-center shadow transition-colors"
-                    prop.ariaLabel "Back to Game"
-                    prop.title "Back to Soccer Game"
-                    prop.onClick (fun _ -> dispatch (NavigateToPage GamePage))
-                    prop.children [
-                      Html.img [
-                        prop.src "assets/soccer.svg"
-                        prop.alt "Soccer Game"
-                        prop.className "w-5 h-5"
-                      ]
-                    ]
+                    prop.className "hover:bg-purple-700 px-4 py-2 rounded-lg transition-colors"
+                    prop.text (string state.OppScore)
+                    prop.onClick (fun _ -> dispatch (ShowModal OpposingTeamScoreModal))
+                    prop.title "Click to add score for opposing team"
                   ]
+                ]
               ]
+
+            // Navigation icons in top right (changes based on current page)
+            Html.div [
+              prop.className "flex items-center gap-2"
+              prop.children (navigationButtons dispatch state)
             ]
           ]
         ]
 
-        Html.div [
-          prop.className "flex bg-purple-200 gap-4 p-4 justify-center";
-          prop.children [
-            Html.button [
-              prop.className "bg-purple-200 text-3xl font-bold text-center";
-              prop.onClick (fun _ -> dispatch (ShowModal TimeManagerModal))
-              prop.text (Time.formatMMSS (State.getElapsedSecondsInHalf state))
+        if state.CurrentPage <> LandingPage then
+          Html.div [
+            prop.className "flex bg-purple-200 gap-4 p-4 justify-center"
+            prop.children [
+              Html.button [
+                prop.className "bg-purple-200 text-3xl font-bold text-center"
+                prop.onClick (fun _ -> dispatch (ShowModal TimeManagerModal))
+                prop.text (Time.formatMMSS (State.getElapsedSecondsInHalf state))
+              ]
             ]
           ]
-        ]
+        else
+          Html.none
       ]
     ]
 

--- a/src/BenchBoss/State.fs
+++ b/src/BenchBoss/State.fs
@@ -7,23 +7,60 @@ open BenchBossApp.Components.BenchBoss.Types
 [<RequireQualifiedAccess>]
 module State =
 
+  let private defaultFieldSlots = 4
+  let private maxFieldSlots = 11
+
+  let private clampFieldSlots slots =
+    slots
+    |> max 1
+    |> min maxFieldSlots
+
+  let private enforceFieldSlotLimit (slots:int) (players: GamePlayer list) =
+    let clampedSlots = clampFieldSlots slots
+    let onFieldPlayers =
+      players
+      |> List.filter (fun p -> p.InGameStatus = OnField)
+
+    if onFieldPlayers.Length <= clampedSlots then
+      players
+    else
+      let playersToKeep =
+        onFieldPlayers
+        |> List.sortBy (fun p -> (p.PlayedSeconds, p.Name))
+        |> List.take clampedSlots
+        |> List.map _.Id
+        |> Set.ofList
+
+      players
+      |> List.map (fun p ->
+          if p.InGameStatus = OnField && not (playersToKeep.Contains p.Id) then
+            { p with InGameStatus = OnBench }
+          else
+            p)
+
   let private validateState (state: State) : State =
     // Ensure Game Players only contains valid player IDs
     let validPlayerIds = state.TeamPlayers |> List.map _.Id |> Set.ofList
-    let validGamePlayers = 
-      state.Game.Players 
+    let validGamePlayers =
+      state.Game.Players
       |> List.filter (fun gp -> validPlayerIds.Contains gp.Id)
 
-    let validatedGame = { state.Game with Players = validGamePlayers }
-    
+    let clampedSlots = clampFieldSlots state.Game.FieldSlots
+    let normalizedPlayers = enforceFieldSlotLimit clampedSlots validGamePlayers
+
+    let validatedGame =
+      { state.Game with
+          Players = normalizedPlayers
+          FieldSlots = clampedSlots }
+
     { state with Game = validatedGame }
 
 
   let private empty () : State =
     {
-      CurrentPage = GamePage
+      CurrentPage = LandingPage
       TeamPlayers = []
-      Game = Game.create "Default Game" []
+      Game = Game.create "Default Game" defaultFieldSlots []
       OurScore = 0
       OppScore = 0
       Events = []
@@ -269,6 +306,47 @@ module State =
     | HideModal ->
         { state with CurrentModal = NoModal }, Cmd.none
     | NavigateToPage page -> { state with CurrentPage = page }, Cmd.none
+    | SetFieldSlots slots ->
+        let clamped = clampFieldSlots slots
+        let normalizedPlayers = enforceFieldSlotLimit clamped state.Game.Players
+        let updatedGame =
+          { state.Game with
+              FieldSlots = clamped
+              Players = normalizedPlayers }
+        { state with Game = updatedGame }, Cmd.none
+    | UpdateGameName name ->
+        let trimmed = name.Trim()
+        let updatedGame = { state.Game with Name = trimmed }
+        { state with Game = updatedGame }, Cmd.none
+    | StartGame ->
+        let sortedPlayers =
+          state.Game.Players
+          |> List.sortBy (fun p -> p.Name)
+
+        let updatedPlayers =
+          sortedPlayers
+          |> List.mapi (fun idx p ->
+              if idx < state.Game.FieldSlots then
+                { p with InGameStatus = OnField; PlayedSeconds = 0; BenchedSeconds = 0 }
+              else
+                { p with InGameStatus = OnBench; PlayedSeconds = 0; BenchedSeconds = 0 })
+
+        let updatedGame =
+          { state.Game with
+              Players = updatedPlayers
+              Timer = Stopped
+              ElapsedSecondsInHalf = 0 }
+
+        let newState =
+          { state with
+              Game = updatedGame
+              OurScore = 0
+              OppScore = 0
+              Events = []
+              LastTick = None
+              CurrentModal = NoModal
+              CurrentPage = GamePage }
+        newState, Cmd.none
     | ConfirmAddTeamPlayer name ->
       match name.Trim() with
       | "" -> state, Cmd.none
@@ -295,10 +373,10 @@ module State =
     | TogglePlayerGameAvailability playerId ->
         togglePlayerGameAvailability playerId state
     | ResetGame ->
-      let newGame = Game.create "Default Game" []
-      let newState = 
-        { state with 
-            CurrentPage = GamePage
+      let newGame = Game.create "Default Game" defaultFieldSlots []
+      let newState =
+        { state with
+            CurrentPage = LandingPage
             Game = newGame
             OurScore = 0
             OppScore = 0

--- a/src/BenchBoss/Types.fs
+++ b/src/BenchBoss/Types.fs
@@ -58,6 +58,7 @@ module Types =
     | EditPlayerModal of TeamPlayer
 
   type Page =
+    | LandingPage
     | GamePage
     | ManageTeamPage
 
@@ -82,16 +83,18 @@ module Types =
     Players: GamePlayer list
     ElapsedSecondsInHalf: int
     Timer: Timer
+    FieldSlots: int
   }
 
   module Game =
 
-    let create name players =
+    let create name fieldSlots players =
       { Id = Guid.NewGuid()
         Name = name
         Players = players
         ElapsedSecondsInHalf = 0
-        Timer = Stopped }
+        Timer = Stopped
+        FieldSlots = fieldSlots }
 
     let addPlayer (teamPlayer: TeamPlayer) game =
       let gamePlayer = GamePlayer.ofTeamPlayer teamPlayer
@@ -142,6 +145,9 @@ module Types =
     | ShowModal of ModalType
     | HideModal
     | NavigateToPage of Page
+    | SetFieldSlots of int
+    | UpdateGameName of string
+    | StartGame
     | ConfirmAddTeamPlayer of string
     | ConfirmUpdateTeamPlayer of TeamPlayer
     | ConfirmRemoveTeamPlayer of PlayerId

--- a/src/BenchBossApp.fsproj
+++ b/src/BenchBossApp.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="BenchBoss\Modals\OpposingTeam.fs" />
     <Compile Include="BenchBoss\Modals\TimeManager.fs" />
     <Compile Include="BenchBoss\Layout.fs" />
+    <Compile Include="BenchBoss\LandingPage.fs" />
     <Compile Include="BenchBoss\GamePage.fs" />
     <Compile Include="BenchBoss\ManageTeamPage.fs" />
     <Compile Include="BenchBoss\BenchBoss.fs" />


### PR DESCRIPTION
## Summary
- add a dedicated landing page that lets users name a game, choose players, and configure field positions before starting
- extend the Elmish state to track landing workflow, configurable field slots, and start-game actions
- update layout navigation and in-game field rendering to integrate the new setup flow

## Testing
- `npm run build` *(fails: dotnet not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7dffcc1908333a95c76708bbaa82c